### PR TITLE
feat: introducing new ECR Module

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
       - checkout
       - add_ssh_keys:
           fingerprints:
-            - "11:1e:b4:dd:8b:ec:90:a5:0a:84:49:08:8e:32:94:e5"
+            - "c4:03:1e:48:4c:d4:dd:8b:5a:e3:59:8c:18:4e:00:d5"
       - run: scripts/release.sh trigger
   release:
     executor: alpine

--- a/examples/default/README.md
+++ b/examples/default/README.md
@@ -12,6 +12,7 @@ terraform {
 }
 
 provider "lacework" {}
+
 provider "aws" {
   region = "us-west-2"
 }

--- a/examples/default/README.md
+++ b/examples/default/README.md
@@ -1,0 +1,23 @@
+# Default Lacework ECR Integration
+
+This example creates a new least privilege IAM Role to access the Amazon Container Registry of the account running the automation and integrates it with Lacework.
+
+```hcl
+terraform {
+  required_providers {
+    lacework = {
+      source = "lacework/lacework"
+    }
+  }
+}
+
+provider "lacework" {}
+provider "aws" {
+  region = "us-west-2"
+}
+
+module "lacework_ecr" {
+  source  = "lacework/ecr/aws"
+  version = "~> 0.1"
+}
+```

--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -1,7 +1,6 @@
 provider "lacework" {}
-provider "aws" {
-  region = "us-west-2"
-}
+
+provider "aws" {}
 
 module "lacework_ecr" {
   source = "../.."

--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -1,0 +1,8 @@
+provider "lacework" {}
+provider "aws" {
+  region = "us-west-2"
+}
+
+module "lacework_ecr" {
+  source = "../.."
+}

--- a/examples/default/versions.tf
+++ b/examples/default/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 0.12.26"
+
+  required_providers {
+    aws = "~> 3.0"
+    lacework = {
+      source = "lacework/lacework"
+    }
+  }
+}

--- a/examples/multi-region/README.md
+++ b/examples/multi-region/README.md
@@ -1,0 +1,55 @@
+# Multi-region ECR Integration
+
+This example show how to integrate multiple Amazon Container Registries (ECR) from multple regions with the same IAM Role
+and integrate them with Lacework.
+
+```hcl
+terraform {
+  required_providers {
+    lacework = {
+      source = "lacework/lacework"
+    }
+  }
+}
+
+provider "lacework" {}
+
+provider "aws" {
+  alias  = "west2"
+  region = "us-west-2"
+}
+
+module "lacework_ecr_west" {
+  source = "../.."
+  providers = {
+    aws = aws.west2
+  }
+}
+
+provider "aws" {
+  alias  = "east1"
+  region = "us-east-1"
+}
+
+module "lacework_ecr_east" {
+  source = "../.."
+  providers = {
+    aws = aws.west2
+  }
+  use_existing_iam_role = true
+  iam_role_name         = module.lacework_ecr_west.iam_role_name
+  iam_role_arn          = module.lacework_ecr_west.iam_role_arn
+  iam_role_external_id  = module.lacework_ecr_west.external_id
+}
+```
+
+## Verifying Integrations with the Lacework CLI
+
+To verify that the integrations were created successfully you can use the Lacework CLI with the command:
+```
+$ lacework int list --type CONT_VULN_CFG
+                      INTEGRATION GUID                               NAME               TYPE        STATUS    STATE
+-----------------------------------------------------------+----------------------+---------------+---------+--------
+  MINIALLY_3884B70BF5F60803A1EB9A7B5238F78FFFD8DE746C2D6DC   TF ECR IAM Role        CONT_VULN_CFG   Enabled   Ok
+  MINIALLY_9293C0545824CF31E4D29AA3D2BE425189ED2D56F45B0B0   TF ECR IAM Role        CONT_VULN_CFG   Enabled   Ok
+``

--- a/examples/multi-region/main.tf
+++ b/examples/multi-region/main.tf
@@ -1,0 +1,29 @@
+provider "lacework" {}
+
+provider "aws" {
+  alias  = "west2"
+  region = "us-west-2"
+}
+
+module "lacework_ecr_west" {
+  source = "../.."
+  providers = {
+    aws = aws.west2
+  }
+}
+
+provider "aws" {
+  alias  = "east1"
+  region = "us-east-1"
+}
+
+module "lacework_ecr_east" {
+  source = "../.."
+  providers = {
+    aws = aws.west2
+  }
+  use_existing_iam_role = true
+  iam_role_name         = module.lacework_ecr_west.iam_role_name
+  iam_role_arn          = module.lacework_ecr_west.iam_role_arn
+  iam_role_external_id  = module.lacework_ecr_west.external_id
+}

--- a/examples/multi-region/versions.tf
+++ b/examples/multi-region/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 0.12.26"
+
+  required_providers {
+    aws = "~> 3.0"
+    lacework = {
+      source = "lacework/lacework"
+    }
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -1,1 +1,43 @@
+locals {
+  registry_domain = length(var.registry_domain) > 0 ? var.registry_domain : (
+    "${data.aws_caller_identity.current.account_id}.dkr.ecr.${data.aws_region.current.name}.amazonaws.com"
+  )
+  iam_role_arn         = module.lacework_ecr_iam_role.created ? module.lacework_ecr_iam_role.arn : var.iam_role_arn
+  iam_role_name        = module.lacework_ecr_iam_role.created ? module.lacework_ecr_iam_role.name : var.iam_role_name
+  iam_role_external_id = module.lacework_ecr_iam_role.created ? module.lacework_ecr_iam_role.external_id : var.iam_role_external_id
+}
 
+data "aws_region" "current" {}
+data "aws_caller_identity" "current" {}
+
+module "lacework_ecr_iam_role" {
+  source                  = "lacework/iam-role/aws"
+  version                 = "~> 0.2"
+  create                  = var.use_existing_iam_role ? false : true
+  iam_role_name           = var.iam_role_name
+  lacework_aws_account_id = var.lacework_aws_account_id
+  external_id_length      = var.external_id_length
+  tags                    = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "ecr_read_only_policy_attachment" {
+  role       = local.iam_role_name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+  depends_on = [module.lacework_ecr_iam_role]
+}
+
+# wait for X seconds for things to settle down in the AWS side
+# before trying to create the Lacework external integration
+resource "time_sleep" "wait_time" {
+  create_duration = var.wait_time
+  depends_on      = [aws_iam_role_policy_attachment.ecr_read_only_policy_attachment]
+}
+
+resource "lacework_integration_ecr" "iam_role" {
+  name            = var.lacework_integration_name
+  registry_domain = local.registry_domain
+  credentials {
+    role_arn    = local.iam_role_arn
+    external_id = local.iam_role_external_id
+  }
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,25 @@
-output "ssm_document_name" {
-  description = "Name of the AWS SSM Document that setups the Lacework agent"
-  value       = aws_ssm_document.setup_lacework_agent.name
+output "external_id" {
+  value       = local.iam_role_external_id
+  description = "The External ID configured into the IAM role"
+}
+
+output "iam_role_name" {
+  value       = var.iam_role_name
+  description = "The IAM Role name"
+}
+
+output "iam_role_arn" {
+  value       = local.iam_role_arn
+  description = "The IAM Role ARN"
+}
+
+output "registry_domain" {
+  value       = local.registry_domain
+  description = "The registry domain configured"
+}
+
+variable "lacework_integration_name" {
+  type        = string
+  default     = "TF ECR IAM Role"
+  description = "The name of the external ECR integration"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -4,7 +4,7 @@ output "external_id" {
 }
 
 output "iam_role_name" {
-  value       = var.iam_role_name
+  value       = local.iam_role_name
   description = "The IAM Role name"
 }
 
@@ -16,10 +16,4 @@ output "iam_role_arn" {
 output "registry_domain" {
   value       = local.registry_domain
   description = "The registry domain configured"
-}
-
-variable "lacework_integration_name" {
-  type        = string
-  default     = "TF ECR IAM Role"
-  description = "The name of the external ECR integration"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,1 +1,53 @@
+variable "registry_domain" {
+  type        = string
+  default     = ""
+  description = "The registry domain to configure"
+}
 
+variable "use_existing_iam_role" {
+  type        = bool
+  default     = false
+  description = "Set this to true to use an existing IAM role"
+}
+
+variable "iam_role_arn" {
+  type        = string
+  default     = ""
+  description = "The IAM role ARN. required when setting use_existing_iam_role to true"
+}
+
+variable "iam_role_external_id" {
+  type        = string
+  default     = ""
+  description = "The external ID configured inside the IAM role. required when setting use_existing_iam_role to true"
+}
+
+variable "iam_role_name" {
+  type        = string
+  default     = ""
+  description = "The IAM role name. Required to match with iam_role_arn if use_existing_iam_role is set to true"
+}
+
+variable "external_id_length" {
+  type        = number
+  default     = 16
+  description = "The length of the external ID to generate. Max length is 1224. Ignored when use_existing_iam_role is set to true"
+}
+
+variable "lacework_aws_account_id" {
+  type        = string
+  default     = "434813966438"
+  description = "The Lacework AWS account that the IAM role will grant access"
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "A map/dictionary of Tags to be assigned to created resources"
+  default     = {}
+}
+
+variable "wait_time" {
+  type        = string
+  default     = "15s"
+  description = "Amount of time to wait before the next resource is provisioned"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -51,3 +51,9 @@ variable "wait_time" {
   default     = "15s"
   description = "Amount of time to wait before the next resource is provisioned"
 }
+
+variable "lacework_integration_name" {
+  type        = string
+  default     = "TF ECR IAM Role"
+  description = "The name of the external ECR integration"
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,11 +1,12 @@
 terraform {
-  required_version = ">= 0.12.0"
+  required_version = ">= 0.12.26"
 
   required_providers {
-    aws = "~> 3.0"
+    aws  = "~> 3.0"
+    time = "~> 0.6"
     lacework = {
       source  = "lacework/lacework"
-      version = "~> 0.2"
+      version = "~> 0.3"
     }
   }
 }


### PR DESCRIPTION
As a Lacework user that uses Terraform,
I want to be able to create an IAM Role to integrate Elastic Container Registry (ECR) with Lacework using Terraform,
So I don't have to worry about creating an IAM Role manually.

# Default Lacework ECR Integration

This example creates a new least privilege IAM Role to access the Amazon Container Registry of the account running the automation and integrates it with Lacework.

```hcl
terraform {
  required_providers {
    lacework = {
      source = "lacework/lacework"
    }
  }
}

provider "lacework" {}
provider "aws" {
  region = "us-west-2"
}

module "lacework_ecr" {
  source  = "lacework/ecr/aws"
  version = "~> 0.1"
}
```
Signed-off-by: Salim Afiune Maya <afiune@lacework.net>