### PR TITLE
fix: delay integration creation X seconds

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -40,4 +40,5 @@ resource "lacework_integration_ecr" "iam_role" {
     role_arn    = local.iam_role_arn
     external_id = local.iam_role_external_id
   }
+  depends_on = [time_sleep.wait_time]
 }


### PR DESCRIPTION
We forgot to add a depends on to wait for the role to be attached.

![tenor-229608093](https://user-images.githubusercontent.com/5712253/111806225-6328f580-8897-11eb-9130-fcae189e4637.gif)


Signed-off-by: Salim Afiune Maya <afiune@lacework.net>