### PR TITLE
fix: bump Lacework provider version to ~> v0.11

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -6,7 +6,7 @@ terraform {
     time = "~> 0.6"
     lacework = {
       source  = "lacework/lacework"
-      version = "~> 0.3"
+      version = "~> 0.11"
     }
   }
 }


### PR DESCRIPTION

***Issue***:  https://github.com/lacework/terraform-aws-ecr/issues/19

***Description:***
We started using the argument `non_os_package_support` that was
introduced in the Lacework provider version `v0.11.0`, we needed
to bump the version and we forgot.

Fixes https://github.com/lacework/terraform-aws-ecr/issues/19

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>

