### PR TITLE
Updated ECR module to set non_os_package_support as default to true a…

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A Terraform Module to integrate Amazon Container Registries (ECR) with Lacework.
 | tags                      | A map/dictionary of Tags to be assigned to created resources                                                     | `map(string)` | `{}`                | no       |
 | wait_time                 | Amount of time to wait before the next resource is provisioned                                                   | `string`      | `"15s"`             | no       |
 | lacework_integration_name | The name of the external ECR integration                                                                         | `string`      | `"TF ECR IAM ROLE"` | no       |
-| non_os_package_support    | Whether or not the integration should check non-os packages in the container for vulnerabilities                 | `bool`        | `false`             | no       |
+| non_os_package_support    | Whether or not the integration should check non-os packages in the container for vulnerabilities                 | `bool`        | `true`             | no       |
 | `limit_by_tags` |A list of image tags to limit the assessment of images with matching tags. If you specify limit_by_tags and limit_by_labels limits, they function as an AND. Supported field input can be ["mytext\*mytext", "mytext", "mytext\*", "mytext". Only one * wildcard is supported.| `list(string)` | no |
 | `limit_by_labels` |A list of image labels to limit the assessment of images with matching labels. If you specify limit_by_tags and limit_by_labels limits, they function as an AND. Supported field input can be ["mytext\*mytext", "mytext", "mytext*", "mytext"].Only one * wildcard is supported.| `list(string)` | no |
 | `limit_by_repositories` |A list of repositories to assess.| `list(string)` | no |

--- a/examples/configure-lacework-ecr-integration/README.md
+++ b/examples/configure-lacework-ecr-integration/README.md
@@ -18,6 +18,7 @@ provider "aws" {}
 module "lacework_ecr" {
   source  = "lacework/ecr/aws"
   version = "~> 0.1"
+  non_os_package_support = true
 
   limit_by_tags         = ["example*"]
   limit_by_labels       = {example: "example"}

--- a/examples/configure-lacework-ecr-integration/main.tf
+++ b/examples/configure-lacework-ecr-integration/main.tf
@@ -4,7 +4,7 @@ provider "aws" {}
 
 module "lacework_ecr" {
   source = "../.."
-  
+  non_os_package_support = true
   limit_by_tags         = ["example*"]
   limit_by_labels       = {example: "example"}
   limit_by_repositories = ["foo","bar"]

--- a/examples/default/README.md
+++ b/examples/default/README.md
@@ -18,5 +18,6 @@ provider "aws" {}
 module "lacework_ecr" {
   source  = "lacework/ecr/aws"
   version = "~> 0.1"
+  non_os_package_support = true
 }
 ```

--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -4,4 +4,5 @@ provider "aws" {}
 
 module "lacework_ecr" {
   source = "../.."
+  non_os_package_support = true
 }

--- a/examples/multi-region/README.md
+++ b/examples/multi-region/README.md
@@ -21,6 +21,7 @@ provider "aws" {
 
 module "lacework_ecr_west" {
   source = "../.."
+  non_os_package_support = true
   providers = {
     aws = aws.west2
   }
@@ -33,6 +34,7 @@ provider "aws" {
 
 module "lacework_ecr_east" {
   source = "../.."
+  non_os_package_support = true
   providers = {
     aws = aws.west2
   }

--- a/examples/multi-region/main.tf
+++ b/examples/multi-region/main.tf
@@ -10,6 +10,7 @@ module "lacework_ecr_west" {
   providers = {
     aws = aws.west2
   }
+  non_os_package_support = true
 }
 
 provider "aws" {
@@ -22,6 +23,7 @@ module "lacework_ecr_east" {
   providers = {
     aws = aws.west2
   }
+  non_os_package_support = true
   use_existing_iam_role = true
   iam_role_name         = module.lacework_ecr_west.iam_role_name
   iam_role_arn          = module.lacework_ecr_west.iam_role_arn

--- a/variables.tf
+++ b/variables.tf
@@ -78,6 +78,6 @@ variable "lacework_integration_name" {
 
 variable "non_os_package_support" {
   type        = bool
-  default     = false
+  default     = true
   description = "Whether or not the integration should check non-os packages in the container for vulnerabilities"
 }


### PR DESCRIPTION
…s well as links

Signed-off-by: Robert Wedd <robert.wedd@lacework.net>

---
name: Update Non OS Package Support
about: 'updated Documentation & examples'
---

***Issue***: [Include link to the Jira/Github Issue](https://lacework.atlassian.net/browse/ALLY-796)

***Description:***
Due to the change in the platform setting nonOS Package to true by default the modules need to be changed to reflect this accordingly. Updated Documentation / Variables & LInks
