### PR TITLE
chore(example): lacework_ecr_east should point to east region

### DIFF
--- a/examples/multi-region/main.tf
+++ b/examples/multi-region/main.tf
@@ -20,7 +20,7 @@ provider "aws" {
 module "lacework_ecr_east" {
   source = "../.."
   providers = {
-    aws = aws.west2
+    aws = aws.east1
   }
   use_existing_iam_role = true
   iam_role_name         = module.lacework_ecr_west.iam_role_name


### PR DESCRIPTION
## Summary

The lacework_ecr_east module referenced the aws.west2 provider rather than the intended aws.east1 provider. Now the providers section of the lacework_ecr_east module includes aws.east1

## How did you test this change?

Using the `terraform plan` action we can inspect the intended result of the terraform configuration file `examples/multi-region/main.tf`. By comparing the outputs of terraform plan generated by the current main branch and the plan generated by the proposed changes, it is possible to see that within `module.lacework_ecr_east` no "east" region is referenced.

### Abbreviated Plan Generated **BEFORE** Pull Request
```shell
# module.lacework_ecr_east.lacework_integration_ecr.iam_role will be created
  + resource "lacework_integration_ecr" "iam_role" {
      + aws_auth_type           = (known after apply)
      + created_or_updated_by   = (known after apply)
      ...
      + registry_domain         = "aws_account_id.dkr.ecr.us-west-2.amazonaws.com"
      + type_name               = (known after apply)

      + credentials {
          + external_id = (known after apply)
          + role_arn    = (known after apply)
        }
    }
```
Here, `registry_domain         = "aws_account_id.dkr.ecr.us-west-2.amazonaws.com"` is the line we notice and wish to compare after the proposed changes.

### Abbreviated Plan Generated **AFTER** Pull Request
```shell
# module.lacework_ecr_east.lacework_integration_ecr.iam_role will be created
  + resource "lacework_integration_ecr" "iam_role" {
      + aws_auth_type           = (known after apply)
      + created_or_updated_by   = (known after apply)
      ...
      + registry_domain         = "aws_account_id.dkr.ecr.us-east-1.amazonaws.com"
      + type_name               = (known after apply)

      + credentials {
          + external_id = (known after apply)
          + role_arn    = (known after apply)
        }
    }
```
After the proposed changes have been applied, the `registry_domain` is set to `aws_account_id.dkr.ecr.us-east-1.amazonaws.com`


## Issue
<N/A>
