### PR TITLE
chore: update Lacework provider version to v1

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -6,7 +6,7 @@ terraform {
     time = "~> 0.6"
     lacework = {
       source  = "lacework/lacework"
-      version = "~> 0.26"
+      version = "~> 1.0"
     }
   }
 }


### PR DESCRIPTION
set version of terraform-provider-lacework to 1.0.0

[_Created by Sourcegraph batch change `darren.murray/terraform-provider-updater`._](https://lacework.sourcegraph.com/users/darren.murray/batch-changes/terraform-provider-updater)