### PR TITLE
Fix 1.1 breaking change in upstream `lacework_ecr_integration`

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -42,8 +42,15 @@ resource "lacework_integration_ecr" "iam_role" {
     external_id = local.iam_role_external_id
   }
   limit_by_tags         = var.limit_by_tags
-  limit_by_labels       = var.limit_by_labels
   limit_by_repositories = var.limit_by_repositories
   limit_num_imgs        = var.limit_num_imgs
-  depends_on            = [time_sleep.wait_time]
+  dynamic "limit_by_label" {
+    for_each = var.limit_by_labels
+    content {
+      key   = limit_by_label.key
+      value = limit_by_label.value
+    }
+  }
+
+  depends_on = [time_sleep.wait_time]
 }

--- a/versions.tf
+++ b/versions.tf
@@ -6,7 +6,7 @@ terraform {
     time = "~> 0.6"
     lacework = {
       source  = "lacework/lacework"
-      version = "~> 1.0"
+      version = "~> 1.1"
     }
   }
 }


### PR DESCRIPTION
## Summary

With the release of `lacework/lacework` version 1.1, a breaking change has been introduced to the resource `lacework_integration_ecr` ([commit reference](https://github.com/lacework/terraform-provider-lacework/commit/658d10f7503a875265600467fcdce094636f1260))

The change is that the previous map `limit_by_labels` got replaced by `limit_by_label` block. This module should update the usage of `lacework_integration_ecr` to comply with the breaking change.

## How did you test this change?

Locally doing a `terraform plan`
