### PR TITLE
feat: add support for AWS provider v5

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.14"
 
   required_providers {
-    aws  = ">= 3.0, < 6.0.0"
+    aws  = ">= 3.0"
     time = "~> 0.6"
     lacework = {
       source  = "lacework/lacework"


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-cloudtrail/blob/main/CONTRIBUTING.md
--->

## Summary

We would like to be able to [upgrade to AWS provider v5.0](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-5-upgrade), which was [just recently released](https://github.com/hashicorp/terraform-provider-aws/releases/tag/v5.0.0).

## How did you test this change?

Clone this repo locally, change the version pin, then change my `source` for the module to point at my local copy. Then I ran a `terraform plan` and verified that it works, with no diffs.

## Issue

https://github.com/lacework/terraform-aws-ecr/issues/45
